### PR TITLE
Plain Archive jar 생성 비활성화

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,3 +42,7 @@ tasks.withType<KotlinCompile> {
 tasks.withType<Test> {
     useJUnitPlatform()
 }
+
+tasks.getByName<Jar>("jar") {
+    enabled = false
+}


### PR DESCRIPTION
- Dockerfile 의 Copy 를 위해 Plain Archive jar 생성 비활성화